### PR TITLE
Encoder fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/shortcut/wsdl2go
 
 go 1.15
 
-require golang.org/x/net v0.0.0-20210119194325-5f4716e94777
+require (
+	github.com/stretchr/testify v1.7.0
+	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -5,3 +12,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -52,7 +52,12 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		defer f.Close()
+		defer func() {
+			err := f.Close()
+			if err != nil {
+				log.Printf("wsdl2go error when closing destination-file: %v", err)
+			}
+		}()
 		w = f
 	}
 
@@ -76,7 +81,10 @@ func codegen(w io.Writer, opts options, cli *http.Client) error {
 	if err != nil {
 		return err
 	}
-	f.Close()
+	err = f.Close()
+	if err != nil {
+		return err
+	}
 
 	enc := wsdlgo.NewEncoder(w)
 	enc.SetClient(cli)

--- a/soap/client_test.go
+++ b/soap/client_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type StructFieldSetXMLData struct {
@@ -78,7 +80,8 @@ func TestRoundTrip(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		io.Copy(w, r.Body)
+		_, err := io.Copy(w, r.Body)
+		require.NoError(t, err)
 	})
 	s := httptest.NewServer(echo)
 	defer s.Close()
@@ -142,7 +145,8 @@ func TestRoundTripWithAction(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		io.Copy(w, r.Body)
+		_, err := io.Copy(w, r.Body)
+		require.NoError(t, err)
 	})
 	s := httptest.NewServer(echo)
 	defer s.Close()
@@ -213,7 +217,8 @@ func TestRoundTripSoap12(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		io.Copy(w, r.Body)
+		_, err := io.Copy(w, r.Body)
+		require.NoError(t, err)
 	})
 	s := httptest.NewServer(echo)
 	defer s.Close()

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -1367,7 +1367,14 @@ func (ge *goEncoder) genGoStruct(w io.Writer, d *wsdl.Definitions, ct *wsdl.Comp
 
 func (ge *goEncoder) genGoOpStruct(w io.Writer, d *wsdl.Definitions, bo *wsdl.BindingOperation) error {
 	name := goSymbol(bo.Name)
-	function := ge.funcs[name]
+	function, ok := ge.funcs[name]
+	if !ok {
+		function = ge.funcs[bo.Name]
+	}
+
+	if function == nil {
+		log.Panicf("function is nil! BindingOperation-name: %v, GoSymbol-name: %v", bo.Name, name)
+	}
 
 	if function.Input == nil {
 		log.Printf("function input is nil! %v is %v", name, function)

--- a/wsdlgo/encoder_test.go
+++ b/wsdlgo/encoder_test.go
@@ -50,8 +50,8 @@ var EncoderCases = []struct {
 	{F: "soap12wcf.wsdl", G: "soap12wcf.golden", E: nil},
 	{F: "memcache.wsdl", G: "memcache.golden", E: nil},
 	{F: "importer.wsdl", G: "memcache.golden", E: nil},
-	//{F: "data.wsdl", G: "data.golden", E: nil}, // TODO: This test-case panics.
-	//{F: "data_withkeyword.wsdl", G: "data_withkeyword.golden", E: nil}, // TODO: This test-case panics.
+	{F: "data.wsdl", G: "data.golden", E: nil},
+	{F: "data_withkeyword.wsdl", G: "data_withkeyword.golden", E: nil},
 	{F: "localimport.wsdl", G: "localimport.golden", E: nil},
 	{F: "localimport-url.wsdl", G: "localimport.golden", E: nil},
 	{F: "localimport_choice.wsdl", G: "localimport_choice.golden", E: nil},


### PR DESCRIPTION
If the names in the WSDL are inconsistent (sometimes camelCase, sometimes snake_case, sometimes PascalCase, etc), the encoder might get confused, and panic as it can't find the function for the expected goSymbol. By attempting to look for the function by the BindingOperation's name instead of the expected goSymbol-name.